### PR TITLE
Use position sticky for navigation

### DIFF
--- a/css/mod-navigation.scss
+++ b/css/mod-navigation.scss
@@ -4,7 +4,7 @@
         display: none;
     }
 
-    position: fixed;
+    position: sticky;
     top: 0;
     width: 100%;
     z-index: 10;

--- a/header.php
+++ b/header.php
@@ -85,7 +85,6 @@
         </div>
     </div>
 </div>
-<div class="navi-spacer">&nbsp;</div>
 
 <?php if ( WP_DEBUG ) : ?>
     <div class="dev-banner" style="background-color: red; position: fixed; width: 200px;top: 0;z-index: 999; text-align: center;left: calc( 50% - 100px );font-size: 1.5em;">


### PR DESCRIPTION
This solves the problem where the navigation overlaps the content, because there are too many items in the top level navigation and the words wrap